### PR TITLE
스프링 트랜잭션 AOP는 public 메서드만 트랜잭션 적용된다.

### DIFF
--- a/src/test/java/hello/springtx/apply/InitTxTest.java
+++ b/src/test/java/hello/springtx/apply/InitTxTest.java
@@ -1,0 +1,63 @@
+package hello.springtx.apply;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.event.EventListener;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import javax.annotation.PostConstruct;
+
+@SpringBootTest
+public class InitTxTest {
+
+    @Autowired Hello hello;
+
+    @Test
+    void go() {
+        // 초기화 코드(@PostConstruct)는 스프링이 초기화 시점에 호출한다.
+        // 스프링 구동 시 스프링 빈으로 등록 된 Hello 객체 내부의
+        // @PostConstruct 를 확인한 스프링은 구동 시 해당 메소드를 호출한다.
+
+    }
+
+
+    @TestConfiguration
+    static class InitTxTestConfig {
+        @Bean
+        Hello hello() {
+            return new Hello(); // Hello 객체 스프링 빈으로 등록
+        }
+    }
+
+
+    @Slf4j
+    static class Hello {
+
+        @PostConstruct
+        @Transactional
+        public void initV1() {
+            boolean isActive = TransactionSynchronizationManager.isActualTransactionActive();
+            log.info("Hello init @PostConstruct tx active : {}", isActive);
+            // Hello init @PostConstruct tx active : false
+            // 초기화 코드에 @Transactional 을 함께 사용하면, 트랜잭션 적용이 되지 않는다.
+            // 왜? -> 초기화 코드(@PostConstruct)가 먼저 호출된 후 @Transactional 이 호출되기 때문
+            // 그래서 초기화 시점에는 해당 메서드에서 트랜잭션을 획득할 수 없다.
+        }
+
+        @EventListener(ApplicationReadyEvent.class) // 스프링 컨테이너(트랜잭션 AOP 포함)가 모~두 생성되고 난 후 호출함
+        @Transactional
+        public void initV2() {
+            boolean isActive = TransactionSynchronizationManager.isActualTransactionActive();
+            log.info("Hello init ApplicationReadyEvent tx active : {}", isActive);
+
+        }
+
+    }
+
+}

--- a/src/test/java/hello/springtx/apply/InternalCallV2Test.java
+++ b/src/test/java/hello/springtx/apply/InternalCallV2Test.java
@@ -1,0 +1,81 @@
+package hello.springtx.apply;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+@SpringBootTest
+public class InternalCallV2Test {
+
+    @Autowired
+    CallService callService;
+
+    @Test
+    void printProxy() {
+        log.info("callService class={}", callService.getClass());
+        // InternalCallV1Test$CallService$$EnhancerBySpringCGLIB$$21fbb614
+    }
+
+    @Test
+    void externalCallV2() {
+        callService.external();
+    }
+
+    @TestConfiguration
+    static class InternalCallV1TestConfig {
+
+        @Bean
+        CallService callService() {
+            return new CallService(internalService());
+        }
+        // CallService 가 생성되면서 InternelService 객체를 주입받음 -> 생성자 주입
+        // InternalService는 메소드에 @Transactional 이 적용되어 있음 -> AOP 프록시 생성
+
+        @Bean
+        InternalService internalService() {
+            return new InternalService();
+        }
+    }
+
+    @Slf4j
+    @RequiredArgsConstructor
+    static class CallService { // 이 CallService 는 @Transactional 이 없으니 AOP 프록시를 생성하지 않음.
+
+        private final InternalService internalService;
+
+        public void external() {
+            log.info("call external");
+            printTxInfo();
+            internalService.internal(); // 내부 호출을 외부 호출로 변경
+        }
+
+        private void printTxInfo() {
+            boolean txActive = TransactionSynchronizationManager.isActualTransactionActive();
+            log.info("tx active : {}", txActive);
+        }
+    }
+
+    static class InternalService {
+
+        @Transactional // Getting transaction for ~, Completing transaction for ~
+        public void internal() {
+            log.info("call internal");
+            printTxInfo();
+        }
+
+        private void printTxInfo() {
+            boolean txActive = TransactionSynchronizationManager.isActualTransactionActive();
+            log.info("tx active : {}", txActive);
+        }
+
+    }
+
+
+}


### PR DESCRIPTION
스프링 초기화 시점에는 트랜잭션 AOP가 적용되지 않을 수 있다. -> @PostConstruct 와 @Transactional 은 함께 사용하면 트랜잭션 AOP가 적용되지 않을 수 있음.
@EventListener 를 사용해, 스프링 컨테이너가 모두 생성되고 난 후 @Transactional 메소드 호출하면 해결됨