### PR TITLE
데이터 정합성에 어긋나는 테스트 실행

### DIFF
--- a/src/main/java/hello/springtx/propagation/LogRepository.java
+++ b/src/main/java/hello/springtx/propagation/LogRepository.java
@@ -15,17 +15,20 @@ public class LogRepository {
 
     private final EntityManager em;
 
+    // 로그 저장
     @Transactional
     public void save(Log logMessage) {
         log.info("log 저장");
         em.persist(logMessage);
 
+        // 로그 저장 시 예외 발생
         if (logMessage.getMessage().contains("로그예외")) {
             log.info("log 저장 시 예외 발생");
             throw new RuntimeException("예외 발생"); // 만약 예외가 발생하면 롤백된다.
         }
     }
 
+    // 로그 조회
     public Optional<Log> find(String message) {
         return em.createQuery("select l from Log l where l.message = :message", Log.class)
                 .setParameter("message", message)

--- a/src/main/java/hello/springtx/propagation/MemberRepository.java
+++ b/src/main/java/hello/springtx/propagation/MemberRepository.java
@@ -15,12 +15,14 @@ public class MemberRepository {
 
     private final EntityManager em;
 
+    // member 저장
     @Transactional
     public void save(Member member) {
         log.info("member 저장");
         em.persist(member);
     }
 
+    // member 조회
     public Optional<Member> find(String username) {
         return em.createQuery("select m from Member m where m.username = :username", Member.class)
                 .setParameter("username", username)

--- a/src/main/java/hello/springtx/propagation/MemberService.java
+++ b/src/main/java/hello/springtx/propagation/MemberService.java
@@ -12,6 +12,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final LogRepository logRepository;
 
+    // 서비스 계층에 @Transactional이 없을 때 커밋되는 상황
     public void joinV1(String username) {
         Member member = new Member(username);
         Log logMessage = new Log(username);
@@ -25,6 +26,7 @@ public class MemberService {
         log.info("== logRepository 호출 종료 ==");
     }
 
+    // 서비스 계층에 @Transactional이 없을 때 롤백되는 상황 - 예외 발생
     public void joinV2(String username) {
         Member member = new Member(username);
         Log logMessage = new Log(username);

--- a/src/test/java/hello/springtx/propagation/MemberServiceTest.java
+++ b/src/test/java/hello/springtx/propagation/MemberServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
@@ -30,9 +31,30 @@ class MemberServiceTest {
         // when
         memberService.joinV1(username);
 
-        // then
+        // then 모든 데이터가 정상 저장된다
         assertTrue(memberRepository.find(username).isPresent());
         assertTrue(logRepository.find(username).isPresent());
+    }
+
+    /**
+     * MemberService    @Transactional:OFF
+     * MemberRepository @Transactional:ON
+     * LogRepository    @Transactional:ON EXCEPTION
+     *
+     */
+    @Test
+    void outerTxOff_fail() {
+
+        // given
+        String username = "로그예외_outerTxOff_fail";
+
+        // when
+        assertThatThrownBy(() -> memberService.joinV1(username))
+                .isInstanceOf(RuntimeException.class);
+
+        // then 모든 데이터가 정상 저장된다
+        assertTrue(memberRepository.find(username).isPresent()); // 멤버는 저장이 완료
+        assertTrue(logRepository.find(username).isEmpty()); // 로그는 저장 중간에 예외가 터져 저장이 되지 않았기 때문에 empty가 정상이다.
     }
 
 }


### PR DESCRIPTION
멤버는 저장되었지만, 로그 저장 시 에러가 발생해 둘의 데이터 정합성이 깨지는 상황을 만들었다.