### PR TITLE
repository에서 예외가 발생해서 service 계층에서 잡아도 set rollback only 가 설정되면 롤백된다.

### DIFF
--- a/src/main/java/hello/springtx/propagation/LogRepository.java
+++ b/src/main/java/hello/springtx/propagation/LogRepository.java
@@ -3,6 +3,7 @@ package hello.springtx.propagation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -16,7 +17,7 @@ public class LogRepository {
     private final EntityManager em;
 
     // 로그 저장 - 트랜잭션 적용
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW) // 내부 롤백이 발생해도 외부 트랜잭션은 영향을 받지 않게끔 처리
     public void save(Log logMessage) {
         log.info("log 저장");
         em.persist(logMessage);

--- a/src/main/java/hello/springtx/propagation/MemberService.java
+++ b/src/main/java/hello/springtx/propagation/MemberService.java
@@ -28,7 +28,7 @@ public class MemberService {
         log.info("== logRepository 호출 종료 ==");
     }
 
-    // 서비스 계층에 @Transactional이 없을 때 롤백되는 상황 - 예외 발생
+    @Transactional
     public void joinV2(String username) {
         Member member = new Member(username);
         Log logMessage = new Log(username);
@@ -42,7 +42,7 @@ public class MemberService {
             logRepository.save(logMessage);
         } catch (RuntimeException e) {
             log.info("log 저장에 실패했습니다. logMessage={}", logMessage.getMessage());
-            log.info("정상 흐름 반환"); // 로그 저장때문에 고객이 서비스 사용에 방해가 된다면 안되게 때문에 로그 저장시 예외가 터지면 정상 흐름으로 반환한다.
+            log.info("정상 흐름 반환"); // 로그 저장 예외 때문에 고객이 서비스 사용에 방해가 된다면 안되게 때문에 로그 저장시 예외가 터지면 정상 흐름으로 반환한다.
         }
         log.info("== logRepository 호출 종료 ==");
     }

--- a/src/main/java/hello/springtx/propagation/MemberService.java
+++ b/src/main/java/hello/springtx/propagation/MemberService.java
@@ -42,7 +42,7 @@ public class MemberService {
             logRepository.save(logMessage);
         } catch (RuntimeException e) {
             log.info("log 저장에 실패했습니다. logMessage={}", logMessage.getMessage());
-            log.info("정상 흐름 반환"); // 로그 저장 예외 때문에 고객이 서비스 사용에 방해가 된다면 안되게 때문에 로그 저장시 예외가 터지면 정상 흐름으로 반환한다.
+            log.info("정상 흐름 반환"); // 로그 저장 예외 때문에 고객이 서비스 사용에 방해가 된다면 안되게 때문에 로그 저장시 예외가 터지면 정상 흐름으로 반환한다. -> 커밋한다.
         }
         log.info("== logRepository 호출 종료 ==");
     }

--- a/src/test/java/hello/springtx/propagation/MemberServiceTest.java
+++ b/src/test/java/hello/springtx/propagation/MemberServiceTest.java
@@ -136,13 +136,37 @@ class MemberServiceTest {
                 .isInstanceOf(UnexpectedRollbackException.class);
 
         // then 모든 데이터가 롤백된다.
-        assertTrue(memberRepository.find(username).isPresent()); // 서비스에서 예외를 잡았으니 멤버는 저장이 됐겠지? -> NO! 멤버 역시 empty이다.
+        assertTrue(memberRepository.find(username).isEmpty()); // 서비스에서 예외를 잡았으니 멤버는 저장이 됐겠지? -> NO! 멤버 역시 empty이다.
         assertTrue(logRepository.find(username).isEmpty()); // 로그는 저장 중간에 예외가 터져 저장이 되지 않았기 때문에 empty가 정상이다.
 
         // 왜 서비스 계층에서 익셉션을 잡았는데도 멤버가 empty일까?
         // 신규 트랜잭션이 아닌 내부 트랜잭션이기 때문에 set rollback only를 설정하고
         // 서비스 계층에서 예외를 잡았지만, set rollback only가 설정된 것을 확인하고
         // UnExpectedRollbackException 예외로 바꿔서 던진다. -> 결국 롤백된다.
+    }
+
+    /**
+     * MemberService    @Transactional:ON
+     * MemberRepository @Transactional:ON
+     * LogRepository    @Transactional:ON(REQUIRES_NEW) EXCEPTION
+     *
+     */
+    @Test
+    void recoverException_success() {
+
+        // given
+        String username = "로그예외_recoverException_success";
+
+        // when
+        memberService.joinV2(username);
+
+        // then log 저장은 실패하지만, member 저장은 성공한다.
+        assertTrue(memberRepository.find(username).isPresent()); // 서비스에서 예외를 잡았으니 멤버는 저장이 됐겠지? -> YES!
+        assertTrue(logRepository.find(username).isEmpty()); // 로그는 저장 중간에 예외가 터져 저장이 되지 않았기 때문에 empty가 정상이다.
+
+        // REQUIRES_NEW 옵션을 통해 회원가입 시도 로그를 남기는데 실패해도 (내부 트랜잭션 롤백)
+        // 회원가입은 유지된다. (외부 트랜잭션에 영향 x)
+
     }
 
 }


### PR DESCRIPTION
- 논리 트랜잭션 중 하나라도 롤백되면 전체 트랜잭션은 롤백된다.
- 내부 트랜잭션이 롤백 되었는데, 외부 트랜잭션이 커밋되면
    UnexpectedRollbackException 예외가 발생한다. 
- rollbackOnly 상황에서 커밋이 발생하면 UnexpectedRollbackException 예외가 발생한다.

![image](https://user-images.githubusercontent.com/71309757/176643768-6d579e0b-1866-409c-860b-194e163ba6fb.png)
